### PR TITLE
Default Name

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -5,6 +5,12 @@
   "schema": {
     "type": "object",
     "properties": {
+      "name": {
+        "type": "string",
+        "title": "Name",
+        "default": "Lutron",
+        "required": true
+      },
         "secrets": {
             "type": "array",
             "items": {


### PR DESCRIPTION
This will default `Lutron` as the name field, which homebridge uses in the logs the plugin pushes out so instead of display as:
```
homebridge-lutron-caseta-leap (logs)
```
It displays as:
```
Lutron (logs)
```