### PR TITLE
Add message for natively supported device types

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -193,7 +193,7 @@ export class LutronCasetaLeap
             case 'WallDimmer':
             case 'CasetaFanSpeedController': {
                 this.log.info('Device type', d.DeviceType, 'supported natively, skipping setup');
-                continue;
+                return;
             }
 
             // TODO
@@ -205,13 +205,13 @@ export class LutronCasetaLeap
             case 'FourGroupRemote':
             case 'RPSOccupancySensor': {
                 this.log.info('Device type', d.DeviceType, 'not yet supported, skipping setup');
-                continue;
+                return;
             }
 
             // any device we don't know about yet
             default:
                 this.log.info('Device type', d.DeviceType, 'not recognized, skipping setup');
-                continue;
+                return;
         }
 
         try {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -175,12 +175,21 @@ export class LutronCasetaLeap
                         break;
                     }
 
+                    case 'SmartBridge':
+                    case 'WallSwitch':
+                    case 'WallDimmer':
+                    case 'CasetaFanSpeedController': {
+                        this.log.info('Device type', d.DeviceType, 'supported natively, skipping setup');
+                        continue;
+                    }
+
                     // TODO
                     case 'Pico4Button':
                     case 'Pico4ButtonScene':
                     case 'Pico4ButtonZone':
                     case 'Pico4Button2Group':
                     case 'FourGroupRemote':
+                    case 'RPSOccupancySensor':
                     default:
                         this.log.info('Device type', d.DeviceType, 'not yet supported, skipping setup');
                         continue;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -175,6 +175,7 @@ export class LutronCasetaLeap
                         break;
                     }
 
+                    // known devices that are exposed directly to homekit
                     case 'SmartBridge':
                     case 'WallSwitch':
                     case 'WallDimmer':
@@ -184,14 +185,20 @@ export class LutronCasetaLeap
                     }
 
                     // TODO
+                    // known devices that are not exposed to homekit, pending support
                     case 'Pico4Button':
                     case 'Pico4ButtonScene':
                     case 'Pico4ButtonZone':
                     case 'Pico4Button2Group':
                     case 'FourGroupRemote':
-                    case 'RPSOccupancySensor':
-                    default:
+                    case 'RPSOccupancySensor': {
                         this.log.info('Device type', d.DeviceType, 'not yet supported, skipping setup');
+                        continue;
+                    }
+
+                    // any device we don't know about yet
+                    default:
+                        this.log.info('Device type', d.DeviceType, 'not recognized, skipping setup');
                         continue;
                 }
                 try {


### PR DESCRIPTION
I was surprised when I saw the log messages start coming in on first setup with a bunch of "not yet supported, skipping setup". I quickly realized that these devices were the actual switches I have paired to the Caseta bridge, but the message didn't sit right.

Since these devices are intentionally unsupported, I think it makes sense to give them their own message. It also tells the user "don't worry, this is normal".

While I was at it, I added an explicit case to the "not supported" category for the occupancy sensor, since I have the device name in the log. I may come back and add proper support for it since I have one, but I'm not a typescript developer so we'll see 😛 