### PR TITLE
Fix cache restore for Pico4Button2Group

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -139,6 +139,7 @@ export class LutronCasetaLeap
             case 'Pico2ButtonRaiseLower':
             case 'Pico3Button':
             case 'Pico3ButtonRaiseLower':
+            case 'Pico4Button2Group':
             case 'Pico4ButtonZone':
             case 'Pico4ButtonScene':
             {


### PR DESCRIPTION
Fix for incomplete support introduced in #51. My bridge restarted and the pico stopped working. Adding `Pico4Button2Group` to the case statement in `configureAccessory` allows the pico to continue working through bridge restarts.