### PR TITLE
Add device types from RA2 Select range to be ignored

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -256,7 +256,10 @@ export class LutronCasetaLeap
             case 'SmartBridge':
             case 'WallSwitch':
             case 'WallDimmer':
-            case 'CasetaFanSpeedController': {
+            case 'CasetaFanSpeedController':
+            case 'RA2SelectMainRepeater':
+            case 'InLineDimmer':
+            case 'InLineSwitch': {
                 return Promise.reject(
                     new SkipDevice(`Device type ${device.DeviceType} supported natively, skipping setup`),
                 );


### PR DESCRIPTION
After adding the RA2 Select main repeater (bridge) to Homebridge, several error messages were displayed in the log:
```
[Lutron] Failed to process device: Error: Failed to wire new device Living Room Main Lights: Skipping: Device type InLineDimmer not recognized. Please file a ticket and tell me about it
```

The listed device types are supported natively by HomeKit so adding them to the skip list.