### PR TITLE
Add unsupported plugins

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -253,6 +253,8 @@ export class LutronCasetaLeap
             }
 
             // known devices that are exposed directly to homekit
+            case 'OutdoorPlugInSwitch':
+            case 'PlugInDimmer':
             case 'SmartBridge':
             case 'WallSwitch':
             case 'WallDimmer':


### PR DESCRIPTION
Add the [Outdoor Smart Plug][1] and [Lamp Dimming Smart Plug][1].

Fixes #83
Fixes #84

[1]: https://www.casetawireless.com/us/en/products/smart-plugs