### PR TITLE
Adding support for pico paddle remotes

### DIFF
--- a/src/PicoRemote.ts
+++ b/src/PicoRemote.ts
@@ -26,6 +26,12 @@ const BUTTON_MAP = new Map<string, Map<number, { label: string; index: number; i
             [0, { label: 'On', index: 1, isUpDown: false }],
             [2, { label: 'Off', index: 2, isUpDown: false }],
         ]),
+        [
+        'PaddleSwitchPico',
+        new Map([
+            [0, { label: 'On', index: 1, isUpDown: false }],
+            [2, { label: 'Off', index: 2, isUpDown: false }],
+        ]),
     ],
     [
         'Pico2ButtonRaiseLower',

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -329,6 +329,7 @@ export class LutronCasetaLeap
 
             // supported Pico remotes
             case 'Pico2Button':
+            case 'PaddleSwitchPico':
             case 'Pico2ButtonRaiseLower':
             case 'Pico3Button':
             case 'Pico3ButtonRaiseLower':


### PR DESCRIPTION
As referenced in #124 please see changes below--which I modeled after the commit you provided here: https://github.com/thenewwazoo/homebridge-lutron-caseta-leap/commit/d8d26a9f10a472f33ddd7a692cf7b4d497a52278. I'm not super experienced so please forgive me if my changes don't make sense or if this is not the proper way to propose them. 