### PR TITLE
update README to include support for 4 button scene keypads

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ I don't own one of every remote type, so I've had to make guesses about the othe
 * [3-Button](https://www.lutron.com/en-US/pages/SupportCenter/support.aspx?modelNumber=PJ2-3B&Section=Documents) (*untested*)
 * [3-Button with raise/lower](https://www.lutron.com/en-US/pages/SupportCenter/support.aspx?modelNumber=PJ2-3BRL&Section=Documents)
 * [3-Button Shade with raise/lower](https://www.lutron.com/TechnicalDocumentLibrary/369612.pdf) (`-S01`)
-* [4-Button Scene Selector](https://www.lutron.com/TechnicalDocumentLibrary/369847.pdf) (note only `-L01` model is supported)
+* [4-Button](https://www.lutron.com/TechnicalDocumentLibrary/369847.pdf) (note only `-L01` model is supported)
+* [4-Button Scene Keypad](https://www.lutron.com/TechnicalDocumentLibrary/3691066_eng.pdf) (`-P01`)
 * [4-Button Dual Group](https://www.lutron.com/TechnicalDocumentLibrary/369847.pdf) (`-L21`)
 
 I'd love to have complete, tested support of all remote types. If you have hardware that is partially- or un-supported and, adding support is fast and easy. I would also be happy to add support for hardware that is provided to me.


### PR DESCRIPTION
Updating the README per #128.  I only made reference to the remotes that have been verified to work, though my assumption at this point is that `-P02` and `-P03` scene keypads would also work. 

I also updated the description for the `-L01` as that one looks like a standard 4 button, and not one of the scene keypads. 